### PR TITLE
Allow SQL::Maker::Condition and SQL::QueryMaker

### DIFF
--- a/lib/Coteng.pm
+++ b/lib/Coteng.pm
@@ -112,6 +112,14 @@ sub execute {
     $self->dbh->query($self->_expand_args(@_));
 }
 
+sub _validate_where {
+    my ($self, $where) = @_;
+    if (ref($where) ne "HASH" && ref($where) ne "ARRAY"
+        && ref($where) ne "SQL::Maker::Condition" && ref($where) ne "SQL::QueryMaker") {
+        Carp::croak "'where' required to be HASH or ARRAY or SQL::Maker::Condition or SQL::QueryMaker";
+    }
+}
+
 sub single {
     my ($self, $table, $where, $opt) = @_;
     my $class = do {
@@ -122,9 +130,7 @@ sub single {
         $opt = {};
     }
 
-    if (ref($where) ne "HASH" && ref($where) ne "ARRAY") {
-        Carp::croak "'where' required to be HASH or ARRAY";
-    }
+    $self->_validate_where($where);
 
     $opt->{limit} = 1;
 
@@ -148,9 +154,7 @@ sub search {
         $opt = {};
     }
 
-    if (ref($where) ne "HASH" && ref($where) ne "ARRAY") {
-        Carp::croak "'where' required to be HASH or ARRAY";
-    }
+    $self->_validate_where($where);
 
     my ($sql, @binds) = $self->sql_builder->select(
         $table,

--- a/lib/Coteng.pm
+++ b/lib/Coteng.pm
@@ -190,7 +190,7 @@ sub insert {
     }
 
     if (ref($args) ne "HASH" && ref($args) ne "ARRAY") {
-        Carp::croak "'where' required to be HASH or ARRAY";
+        Carp::croak "'args' required to be HASH or ARRAY";
     }
 
     $opt->{primary_key} ||= "id";

--- a/t/01_coteng.t
+++ b/t/01_coteng.t
@@ -107,10 +107,18 @@ local *Coteng::dbh = sub { $dbh };
 subtest single => sub {
     my $id = insert_mock($dbh, name => "mock1");
 
-    subtest 'without class' => sub {
+    subtest 'without class, use hashref' => sub {
         my $row = $coteng->single(mock => {
             id => $id,
         });
+        isa_ok $row, "HASH";
+        is $row->{name}, "mock1";
+    };
+
+    subtest 'without class, use SQL::Maker::Condition' => sub {
+        my $row = $coteng->single(mock =>
+            SQL::Maker::Condition->new->add(id => $id)
+        );
         isa_ok $row, "HASH";
         is $row->{name}, "mock1";
     };
@@ -127,10 +135,19 @@ subtest single => sub {
 subtest search => sub {
     my $id = insert_mock($dbh, name => "mock2");
 
-    subtest 'without class' => sub {
+    subtest 'without class, use hashref' => sub {
         my $rows = $coteng->search(mock => {
             name => "mock2",
         });
+        isa_ok $rows, "ARRAY";
+        is scalar(@$rows), 1;
+        isa_ok $rows->[0], "HASH";
+    };
+
+    subtest 'without class, use SQL::Maker::Condition' => sub {
+        my $rows = $coteng->search(mock =>
+            SQL::Maker::Condition->new->add(name => "mock2")
+        );
         isa_ok $rows, "ARRAY";
         is scalar(@$rows), 1;
         isa_ok $rows->[0], "HASH";


### PR DESCRIPTION
> where clause from hashref or arrayref via SQL::Maker::Condition, or SQL::Maker::Condition object, or SQL::QueryMaker object.

http://search.cpan.org/~tokuhirom/SQL-Maker-1.21/lib/SQL/Maker.pm#METHODS